### PR TITLE
fix: "Honey Bee", not "Honey Been"

### DIFF
--- a/_site/resources.html
+++ b/_site/resources.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <title>Resources | Honey Been Design System</title>
+        <title>Resources | Honey Bee Design System</title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/resources.md
+++ b/resources.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Resources | Honey Been Design System
+title: Resources | Honey Bee Design System
 ---
 ## Resources
 


### PR DESCRIPTION
A couple titles were inadvertently "Honey Been" rather than "Honey Bee", this fixes these.