### PR TITLE
.gitignore .ruby-version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 node_modules
 dist
 /_site
+/.ruby-version
 /.sass-cache


### PR DESCRIPTION
Avoid disrupting local use of `rbenv`