### PR TITLE
docs: suggest bundle exec jekyll serve

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ To build the \_site directory used by Jekyll, use: `jekyll build`
 
 To run the site locally, use: `jekyll serve`
 
+Hint: when that doesn't work, try `bundle exec jekyll serve` .
+
 ## Building for Production
 
 Building for production is easy, just run npm run build-prod to compile and minify all .scss and .js files. This will overwrite any non minified files in the dist directory, this is done so that file paths do not need to be changed when building for prod or working in a dev environment.


### PR DESCRIPTION
I'm not totally clear in *why* I needed to preface with `bundle exec`, but it did locally work, so maybe it'll work for others too.