### PR TITLE
HNYBEE-22 add do-this-not-that include

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,24 +31,36 @@ The site will be available at http://127.0.0.1:4000/uw-it-design-system/
 
 To use the do this, not that idiom, use the `do-this-not-that` `include`.
 
+Do and do not examples consist of:
+
++ the positive example
++ a phrase describing the positive example. The template will prepend "Do " to
+  this phrase.
++ the negative example
++ a phrase describing the negative example. The template will prepand "Don't "
+  to this phrase.
+
 First, capture the examples
 
 ```liquid
 {% capture totally_do_this %}
-This exemplifies doing The Thing with panache.
+Labels are intended to look like this
 {% endcapture %}
 
 {% capture so_do_not_do_this %}
-This exemplifies Doing It Wrong.
+Labels are not intended to look like this.
 {% endcapture %}
 ```
 
-Then, invoke the include, passing along the examples.
+Then, invoke the include, passing along the examples and the phrases.
 
 ```liquid
 {% include do-this-not-that.html
   do-this=totally_do_this
-  not-that=so_do_not_do_this %}
+  do-phrase="use sentence case in labels"
+  not-that=so_do_not_do_this
+  not-phrase="end labels with end punctuation"
+  %}
 ```
 
 In this example, `totally_do_this` and `so_do_not_do_this` are arbitrary

--- a/README.md
+++ b/README.md
@@ -27,6 +27,33 @@ Building for production is easy, just run npm run build-prod to compile and mini
 
 The site will be available at http://127.0.0.1:4000/uw-it-design-system/
 
+## Do and do not includes
+
+To use the do this, not that idiom, use the `do-this-not-that` `include`.
+
+First, capture the examples
+
+```liquid
+{% capture totally_do_this %}
+This exemplifies doing The Thing with panache.
+{% endcapture %}
+
+{% capture so_do_not_do_this %}
+This exemplifies Doing It Wrong.
+{% endcapture %}
+```
+
+Then, invoke the include, passing along the examples.
+
+```liquid
+{% include do-this-not-that.html
+  do-this=totally_do_this
+  not-that=so_do_not_do_this %}
+```
+
+In this example, `totally_do_this` and `so_do_not_do_this` are arbitrary
+identifiers -- use whatever would best label the examples.
+
 ---
 
 Copyright (c) 2019 by Board of Regents of the University of Wisconsin System.

--- a/_includes/do-this-not-that.html
+++ b/_includes/do-this-not-that.html
@@ -1,7 +1,13 @@
 <div>
-{{ include.do-this }}
+  <div>
+    {{ include.do-this }}
+  </div>
+  <div>Do {{ include.do-phrase }}</div>
 </div>
 
 <div>
-{{ include.not-that }}
+  <div>
+    {{ include.not-that }}
+  </div>
+  <div>Don't {{ include.not-phrase }}</div>
 </div>

--- a/_includes/do-this-not-that.html
+++ b/_includes/do-this-not-that.html
@@ -1,4 +1,6 @@
 <div style="display: grid; grid-column-gap: 50px;  grid-template-columns: auto auto;">
+<!-- Desperately needs refactored to use CSS! -->
+
 
 <div style="border-style: solid; border-color:green">
   <div style="border-style: solid;">

--- a/_includes/do-this-not-that.html
+++ b/_includes/do-this-not-that.html
@@ -2,14 +2,14 @@
 <!-- Desperately needs refactored to use CSS! -->
 
 
-<div style="border-style: solid; border-color:green">
+<div style="border-bottom: 5px solid green;">
   <div style="border-style: solid;">
     {{ include.do-this }}
   </div>
   <div><span style="color:green">Do</span> {{ include.do-phrase }}</div>
 </div>
 
-<div style="border-style: solid; border-color:red">
+<div style="border-bottom: 5px solid red;">
   <div style="border-style: solid;">
     {{ include.not-that }}
   </div>

--- a/_includes/do-this-not-that.html
+++ b/_includes/do-this-not-that.html
@@ -1,13 +1,17 @@
-<div>
-  <div>
+<div style="display: grid; grid-column-gap: 50px;  grid-template-columns: auto auto;">
+
+<div style="border-style: solid; border-color:green">
+  <div style="border-style: solid;">
     {{ include.do-this }}
   </div>
   <div>Do {{ include.do-phrase }}</div>
 </div>
 
-<div>
-  <div>
+<div style="border-style: solid; border-color:red">
+  <div style="border-style: solid;">
     {{ include.not-that }}
   </div>
   <div>Don't {{ include.not-phrase }}</div>
+</div>
+
 </div>

--- a/_includes/do-this-not-that.html
+++ b/_includes/do-this-not-that.html
@@ -1,0 +1,7 @@
+<div>
+{{ include.do-this }}
+</div>
+
+<div>
+{{ include.not-that }}
+</div>

--- a/_includes/do-this-not-that.html
+++ b/_includes/do-this-not-that.html
@@ -4,14 +4,14 @@
   <div style="border-style: solid;">
     {{ include.do-this }}
   </div>
-  <div>Do {{ include.do-phrase }}</div>
+  <div><span style="color:green">Do</span> {{ include.do-phrase }}</div>
 </div>
 
 <div style="border-style: solid; border-color:red">
   <div style="border-style: solid;">
     {{ include.not-that }}
   </div>
-  <div>Don't {{ include.not-phrase }}</div>
+  <div><span style="color:red">Don't</span> {{ include.not-phrase }}</div>
 </div>
 
 </div>


### PR DESCRIPTION
This *works*. It's using very clunky ad-hoc styling, needs refactored to external CSS and styled with panache.

Still, creates, documents a template for do-this-not-that documentation.

<img width="703" alt="screen shot 2019-03-05 at 11 25 59 am" src="https://user-images.githubusercontent.com/952283/53824517-b68eac00-3f39-11e9-9942-686661d55a6e.png">

A local `example.md` successfully invokes the include thusly:

```
---
layout: default
title: Meta example page | UW IT Design System
---

{% capture totally_do_this %}
Labels are intended to look like this
{% endcapture %}

{% capture so_do_not_do_this %}
Labels are not intended to look like this.
{% endcapture %}


{% include do-this-not-that.html
  do-this=totally_do_this
  do-phrase="use sentence case in labels"
  not-that=so_do_not_do_this
  not-phrase="end labels with end punctuation"
  %}

```