### PR TITLE
slurp in the easy-to-implement part of typography guidelines

### DIFF
--- a/docs/foundations/typography.md
+++ b/docs/foundations/typography.md
@@ -4,6 +4,28 @@ title: Typography
 ---
 # Typography
 
+Use the type scale to apply consistent typographic design.
+
+### Typefaces
+
+The UW Madison Design System uses exclusively `Roboto`. The type was chosen
+because it is flexible, accessible and free to use, which is necessary to
+accommodate projects across UW’s campus.
+
++ Primary Font: Roboto
++ Fallback Fonts: Helvetica, Arial
++ Title Font: Verlag
+
+### General Guidelines
+
++ Never end a header or label with a period (.)
++ Only use a period (.) for sentences, paragraphs, and copy.
++ Avoid use of all caps wherever possible.
+
+OPPORTUNITY FOR DO-THIS-NOT-THAT EXAMPLE HERE.
+
+SOME KIND OF DEMONSTRATIVE EXAMPLE GOES HERE
+
 <h1>H1: The quick brown fox jumps over the lazy dog</h1>
 <h2>H2: The quick brown fox jumps over the lazy dog</h2>
 <h3>H3: The quick brown fox jumps over the lazy dog</h3>


### PR DESCRIPTION
Bootstraps `typography.md` to start having real-feeling content. Does not yet address how to show examples of typography.

<img width="703" alt="screen shot 2019-03-05 at 10 41 53 am" src="https://user-images.githubusercontent.com/952283/53821393-53018000-3f33-11e9-86e4-3795ed7a6a56.png">
