### PR TITLE
add copyright statement to table-of-contents sidebar

### DIFF
--- a/_includes/table-of-contents.html
+++ b/_includes/table-of-contents.html
@@ -21,3 +21,5 @@
     </section>
   {% endfor %}
 </nav>
+<footer class="table-of-contents__footer">Copyright (c) 2019 by Board of Regents of the University of Wisconsin
+    System.</footer>

--- a/_sass/_table-of-contents.scss
+++ b/_sass/_table-of-contents.scss
@@ -35,3 +35,9 @@
     text-decoration: none;
   }
 }
+
+.table-of-contents__footer {
+  color: white;
+  padding: 32px 0;
+  margin-left: 32px;
+}


### PR DESCRIPTION
<img width="304" alt="screen shot 2019-03-05 at 3 35 54 pm" src="https://user-images.githubusercontent.com/952283/53839190-7ab90e00-3f5c-11e9-8a33-47ba245e3887.png">
