### PR TITLE
Introduce a "section" layout, generate section index pages

### DIFF
--- a/_layouts/section.html
+++ b/_layouts/section.html
@@ -1,0 +1,21 @@
+---
+layout: default
+---
+
+{% for section in site.data.table-of-contents %}
+  {% if section.name == page.title %}
+    {% if section.items %}
+      <ol>
+      {% for item in section.items %}
+      <li>
+        <a href="{{ site.baseurl }}{{ item.url }}">
+          {{ item.name }}
+        </a>
+      </li>
+      {% endfor %}
+      </ol>
+    {% endif %}
+  {% endif %}
+{% endfor %}
+
+{{ content }}

--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -1,4 +1,9 @@
 ---
-layout: default
-title: Components
+layout: section
+title: UI Components
 ---
+
+Components are the pieces of the design system. Lorem ipsum dolor sit amet
+consectetur adipisicing elit. Saepe hic laboriosam quam veniam minima assumenda
+sit temporibus dicta commodi aperiam ducimus eveniet expedita, iure ex nam, quas
+explicabo quasi. Deleniti?

--- a/docs/foundations/index.md
+++ b/docs/foundations/index.md
@@ -1,4 +1,9 @@
 ---
-layout: default
+layout: section
 title: Foundations
 ---
+
+Foundations are the foundation of the design system. Lorem ipsum dolor sit amet
+consectetur adipisicing elit. Saepe hic laboriosam quam veniam minima assumenda
+sit temporibus dicta commodi aperiam ducimus eveniet expedita, iure ex nam, quas
+explicabo quasi. Deleniti?


### PR DESCRIPTION
Adds a `section` layout that (optionally, index pages opt into it by declaring this layout in frontmatter) generates links to the pages within that section.

Effect on the two section index pages:

<img width="1184" alt="screen shot 2019-03-05 at 4 03 04 pm" src="https://user-images.githubusercontent.com/952283/53840810-c077d580-3f60-11e9-8e32-8d89fd6fb221.png">

<img width="1198" alt="screen shot 2019-03-05 at 4 03 11 pm" src="https://user-images.githubusercontent.com/952283/53840820-c40b5c80-3f60-11e9-9dca-eab0c672a5cb.png">
