### PR TITLE
move view modes docs to includes README

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,58 +167,6 @@ Hint: when that doesn't work, try `bundle exec jekyll serve` .
 
 The site will be available at http://127.0.0.1:4000/uw-it-design-system/
 
-## View Modes
-
-The "Design | Develop" view modes toggle is automatically included on the component layout.
-```
----
-layout: component
-title: Typography
----
-```
-
-Use a capture group to assign content to a specific view. In the example below, we use the capture group `{% capture designer %}` to assign designer specific content to the design view mode.
-
-```
-{% capture designer %}
-	Designer specific content goes here...
-{% endcapture %}
-{% include view-mode.html designer=designer %}
-
-{% capture developer %}
-	Developer specific content goes here...
-{% endcapture %}
-{% include view-mode.html developer=developer %}
-
-```
-
-
-## View Modes
-
-The "Design | Develop" view modes toggle is automatically included on the component layout.
-```
----
-layout: component
-title: Typography
----
-```
-
-Use a capture group to assign content to a specific view. In the example below, we use the capture group `{% capture designer %}` to assign designer specific content to the design view mode.
-
-```
-{% capture designer %}
-	Designer specific content goes here...
-{% endcapture %}
-{% include view-mode.html designer=designer %}
-
-{% capture developer %}
-	Developer specific content goes here...
-{% endcapture %}
-{% include view-mode.html developer=developer %}
-
-```
-
-
 ---
 
 Copyright (c) 2019 by Board of Regents of the University of Wisconsin System.

--- a/_includes/README.md
+++ b/_includes/README.md
@@ -38,3 +38,31 @@ Then, invoke the include, passing along the examples and the phrases.
 
 In this example, `totally_do_this` and `so_do_not_do_this` are arbitrary
 identifiers -- use whatever would best label the examples.
+
+## View Modes
+
+The "Design | Develop" view modes toggle is automatically included on the
+component layout.
+
+```yaml
+---
+layout: component
+title: Typography
+---
+```
+
+Use a capture group to assign content to a specific view. In the example below,
+we use the capture group `{% capture designer %}` to assign designer specific
+content to the design view mode.
+
+```liquid
+{% capture designer %}
+Designer specific content goes here...
+{% endcapture %}
+{% include view-mode.html designer=designer %}
+
+{% capture developer %}
+Developer specific content goes here...
+{% endcapture %}
+{% include view-mode.html developer=developer %}
+```


### PR DESCRIPTION
Move the documentation about view modes to the README associated with includes.