### PR TITLE
Adds copyright to main page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,4 @@
 baseurl: /uw-it-design-system
 sass:
   style: compact
+copyright: Copyright &copy; 2019 by Board of Regents of the University of Wisconsin System.

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,3 @@
+<footer class="uwds-page__sidebar__footer">
+    <small>{{ site.copyright }}</small>
+</footer>  

--- a/_layouts/component.html
+++ b/_layouts/component.html
@@ -13,6 +13,7 @@
           <h1>{{ page.title }}</h1>
           {{ content }}
         </div>
+        {% include footer.html %}
       </div>
     </div>
 		{% include scripts.html %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,17 +6,15 @@
       {% include header.html %}
       <div class="uwds-page__sidebar">
         {% include table-of-contents.html %}
-        <footer class="uwds-page__sidebar__footer">
-          Copyright &copy; 2019 by Board of Regents of the University of Wisconsin System.
-        </footer>
       </div>
       <div class="uwds-page__body">
         <div class="uwds-page__body__column">
           <h1>{{ page.title }}</h1>
           {{ content }}
         </div>
+        {% include footer.html %}
       </div>
     </div>
-		{% include scripts.html %}
+    {% include scripts.html %}
   </body>
 </html>


### PR DESCRIPTION
Removes copyright from sidebar and adds it to the main content page

<img width="1123" alt="screen shot 2019-03-06 at 3 39 18 pm" src="https://user-images.githubusercontent.com/12139428/53915702-0ea2dc80-4026-11e9-9177-ac09a462141c.png">

@thevoiceofzeke @Dedering @lguo35 @apetro 
