### PR TITLE
fix: GitHub Pages apparently using Bundler 1 not 2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,4 +245,4 @@ DEPENDENCIES
   github-pages
 
 BUNDLED WITH
-   2.0.1
+   1.17.2


### PR DESCRIPTION
Seems to be necessary to get local Jekyll build to work.