### PR TITLE
Remove extraneous html and absolute position on toggle

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -18,9 +18,7 @@
       </div>
       <div class="uwds-page__body">
         <div class="uwds-page__body__column">
-          <div class="uwds-page__body__column__content">
             {{ content }}
-          </div>
         </div>
         <footer class="uwds-page__sidebar__footer">
           <small>{{ site.copyright }}</small>

--- a/_sass/_page-general.scss
+++ b/_sass/_page-general.scss
@@ -53,8 +53,7 @@ h4 {
 }
 
 .uwds-view-mode-toggle {
-  position: absolute;
-  right: 0;
+  float: right;
 
   button {
     margin: 0;

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -37,7 +37,7 @@ $color-white-font: #f9f9f9;
 $gutter: 30px;
 $topbar-height: 64px;
 $sidebar-width: 300px;
-$body-max-width: 900px;
+$body-max-width: 850px;
 $breakpoint-medium: 40em;
 
 /* Fonts */

--- a/_sass/regions/_body.scss
+++ b/_sass/regions/_body.scss
@@ -3,12 +3,9 @@
 
   &__column {
     margin-right: auto;
+    margin-left: auto;
+    max-width: $body-max-width;
     padding: $gutter;
-
-    &__content {
-      max-width: $body-max-width;
-      position: relative;
-    }
   }
 }
 


### PR DESCRIPTION
* Removes absolute positioning on `Design | Developer` toggle view so that it stays contained within the main page flow
* Adds max width and auto margins back into main column layout

<img width="1414" alt="screen shot 2019-03-07 at 2 44 57 pm" src="https://user-images.githubusercontent.com/12139428/53987809-a288ad00-40e7-11e9-8562-5e90d5e97052.png">

@ievavold @thevoiceofzeke @apetro @lguo35 