### PR TITLE
Moves copyright element

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,10 +19,10 @@
       <div class="uwds-page__body">
         <div class="uwds-page__body__column">
             {{ content }}
+            <footer class="uwds-page__sidebar__footer">
+              <small>{{ site.copyright }}</small>
+            </footer>
         </div>
-        <footer class="uwds-page__sidebar__footer">
-          <small>{{ site.copyright }}</small>
-        </footer>
       </div>
     </div>
     <script type="text/javascript" src="{{ site.baseurl }}/assets/scripts/vendor/jquery-1.12.0.min.js"></script>

--- a/_sass/regions/_sidebar.scss
+++ b/_sass/regions/_sidebar.scss
@@ -14,8 +14,7 @@
   }
 
   &__footer {
-    padding: 32px 0;
-    margin-left: 32px;
+    margin-top: 5em;
   }
 }
 


### PR DESCRIPTION
* Moves copyright element to stay within flow of main content
* Adds margin top to make a more visual separation between copyright and main content

<img width="1126" alt="screen shot 2019-03-07 at 3 07 09 pm" src="https://user-images.githubusercontent.com/12139428/53989075-b84ba180-40ea-11e9-8467-b3566650f4e6.png">

@ievavold @thevoiceofzeke @apetro @lguo35 